### PR TITLE
add highspeed bauds to list of rates

### DIFF
--- a/server/avnav_nmea.py
+++ b/server/avnav_nmea.py
@@ -193,7 +193,7 @@ class NMEAParser():
 
   #parse a line of NMEA data and store it in the navdata array      
   def parseData(self,data):
-    darray=data.split(",")
+    darray=data.split("*")[0].split(",")
     if len(darray) < 1 or (darray[0][0:1] != "$" and darray[0][0:1] != '!') :
       AVNLog.debug("invalid nmea data (len<1) "+data+" - ignore")
       return False

--- a/server/avnav_serial.py
+++ b/server/avnav_serial.py
@@ -231,7 +231,7 @@ class SerialReader():
       baud=int(self.param['baud'])
       maxerrors=int(self.param['numerrors'])
       minbaud=int(self.param.get('minbaud') or baud)
-      rates=(38400,19200,9600,4800)
+      rates=(115200,57600,38400,19200,9600,4800)
       autobaud=False
       if minbaud != baud and minbaud != 0:
         autobaud=True


### PR DESCRIPTION
Hi Andreas,

newer serial devices based on Arduino/STM/ESP use high baudrates for communication. Here is small fix up to 115200 bauds. Is it enough? Or maybe extend also for 230400, 460800, 921600?

Regards
Oleg aka free-x