### PR TITLE
split filterstring in comma separated parts

### DIFF
--- a/server/handler/pluginhandler.py
+++ b/server/handler/pluginhandler.py
@@ -101,6 +101,7 @@ class ApiImpl(AVNApi):
 
   def fetchFromQueue(self, sequence, number=10,includeSource=False,waitTime=0.5,filter=None):
     if filter is not None:
+      filter=filter.split(',')  
       if not (isinstance(filter,list)):
         filter=[filter]
     return self.queue.fetchFromHistory(sequence,number,includeSource=includeSource,waitTime=waitTime,nmeafilter=filter)


### PR DESCRIPTION
(otherwise filter definitions as documented like  FILTER=
'$HDG,$HDM,$HDT,$VHW' in plugins are not working)