### PR TITLE
Add Length and Beam display for AIS targets fetched from  SignalK

### DIFF
--- a/server/handler/signalkhandler.py
+++ b/server/handler/signalkhandler.py
@@ -184,6 +184,8 @@ def convertAisLon(value):
   return safeGetItem(value, 'longitude')
 def convertAisLat(value):
   return safeGetItem(value, 'latitude')
+def convertAisLength(value):
+  return value.overall;
 
 AISPATHMAP={
   'mmsi':AE('mmsi'),
@@ -195,7 +197,9 @@ AISPATHMAP={
   'lon': AE('navigation.position',converter=convertAisLon),
   'lat': AE('navigation.position',converter=convertAisLat),
   'destination': AE('navigation.destination'),
-  'type': AE('sensors.ais.class',converter=convertAisClass)
+  'type': AE('sensors.ais.class',converter=convertAisClass),
+  'beam': AE('design.beam'),
+  'length': AE('design.length')
 }
 
 class Config(object):
@@ -838,6 +842,7 @@ class AVNSignalKHandler(AVNWorker):
           aisdata={'mmsi':mmsi}
           newestTs=None
           for k,e in AISPATHMAP.items():
+            AVNLog.error("READING AIS %s",e.path)
             av=getFromDict(values,e.path)
             if av is None:
               continue

--- a/viewer/gui/AisInfoPage.jsx
+++ b/viewer/gui/AisInfoPage.jsx
@@ -31,7 +31,9 @@ const displayItems = [
     {name: 'shiptype', label: 'Type'},
     {name: 'passFront', label: 'we pass', addClass: 'aisFront'},
     {name: 'position', label: 'Position'},
-    {name: 'clazz', label: 'Class'}
+    {name: 'clazz', label: 'Class'},
+    {name: 'beam', label: 'Beam'},
+    {name: 'length', label: 'Length'}
 ];
 
 const createUpdateFunction=(config,mmsi)=>{

--- a/viewer/nav/aisformatter.jsx
+++ b/viewer/nav/aisformatter.jsx
@@ -157,8 +157,26 @@ const aisparam={
             if (v.type == 4) return "S";
             return "";
         }
+    },
+    beam: {
+        headline: 'beam',
+            format: function (v) {
+            return v.beam;
+        }
+    },
+    length: {
+        headline: 'length',
+            format: function (v) {
+            if(v.length === undefined)
+            {
+                return v.length;
+            }
+            else
+            {
+                return v.length.overall;
+            }
+        }
     }
-
 };
 
 const AisFormatter={


### PR DESCRIPTION
Adds Length and Beam to AIS targets that are fetched from SignalK. Pretty sure it doesn't work on parsed NMEA sentences.