### PR TITLE
Simpleminded fix for #237

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ windows/**/AvChartConvert.v12.suo
 windows/installer/Output
 windows/installer/library
 android/assets/sounds/**
+bin/

--- a/android/src/main/java/de/wellenvogel/avnav/appapi/DirectoryRequestHandler.java
+++ b/android/src/main/java/de/wellenvogel/avnav/appapi/DirectoryRequestHandler.java
@@ -205,10 +205,25 @@ public class DirectoryRequestHandler extends Worker implements INavRequestHandle
                 if (foundFile == null) return tryFallbackOrFail(uri, handler);
                 ZipFile zf = new ZipFile(foundFile);
                 String entryPath = path.replaceFirst("[^/]*/", "");
-                ZipEntry entry = zf.getEntry(entryPath);
-                if (entry == null) return tryFallbackOrFail(uri, handler);
+                ZipEntry entry = null;
+                if (entryPath.equals("doc.kml") && name.endsWith(".kmz")) {
+                    Enumeration<? extends ZipEntry> entries = zf.entries();
+                    while (entries.hasMoreElements()) {
+                        ZipEntry ze = entries.nextElement();
+                        if (!ze.getName().contains("/") && ze.getName().endsWith(".kml")) {
+                            entry = ze;
+                            break;
+                        }
+                    }
+                } else {
+                    entry = zf.getEntry(entryPath);
+                }
+
+                if (entry == null) 
+                    return tryFallbackOrFail(uri, handler);
+
                 return new ExtendedWebResourceResponse(entry.getSize(),
-                        RequestHandler.mimeType(entryPath),
+                        RequestHandler.mimeType(entry.getName),
                         "", new CloseHelperStream(zf.getInputStream(entry), zf));
             }
         }

--- a/android/src/main/java/de/wellenvogel/avnav/appapi/DirectoryRequestHandler.java
+++ b/android/src/main/java/de/wellenvogel/avnav/appapi/DirectoryRequestHandler.java
@@ -202,11 +202,12 @@ public class DirectoryRequestHandler extends Worker implements INavRequestHandle
             if (parts[0].endsWith(".zip") || parts[0].endsWith(".kmz")) {
                 String name = URLDecoder.decode(parts[0], "UTF-8");
                 File foundFile = findLocalFile(name);
-                if (foundFile == null) return tryFallbackOrFail(uri, handler);
+                if (foundFile == null) 
+                    return tryFallbackOrFail(uri, handler);
                 ZipFile zf = new ZipFile(foundFile);
                 String entryPath = path.replaceFirst("[^/]*/", "");
-                ZipEntry entry = null;
-                if (entryPath.equals("doc.kml") && name.endsWith(".kmz")) {
+                ZipEntry entry = zf.getEntry(entryPath);
+                if (entry == null && entryPath.equals("doc.kml") && name.endsWith(".kmz")) {
                     Enumeration<? extends ZipEntry> entries = zf.entries();
                     while (entries.hasMoreElements()) {
                         ZipEntry ze = entries.nextElement();
@@ -215,8 +216,6 @@ public class DirectoryRequestHandler extends Worker implements INavRequestHandle
                             break;
                         }
                     }
-                } else {
-                    entry = zf.getEntry(entryPath);
                 }
 
                 if (entry == null) 

--- a/server/handler/avndirectorybase.py
+++ b/server/handler/avndirectorybase.py
@@ -369,17 +369,16 @@ class AVNDirectoryHandlerBase(AVNWorker):
     zip = ZipFile(zipname)
     entry = None
     try:
-      if (entryName.lower() == "doc.kml") and zipname.lower().endswith(".kmz"):
+      entry = zip.getinfo(entryName)
+    except KeyError as e:
+      pass
+    if entry is None and (entryName.lower() == "doc.kml") and zipname.lower().endswith(".kmz"):
         # when looking for *.kmz/doc.kml, accept first .kml file found in root, regardless of name
         # just like it says in: https://developers.google.com/kml/documentation/kmzarchives#recommended-directory-structure
         for mbr in zip.infolist():
           if ('/' not in mbr.filename) and mbr.filename.lower().endswith('.kml'):
             entry = mbr
-            break
-      else:
-        entry = zip.getinfo(entryName)
-    except KeyError as e:
-      pass
+            break    
     if entry is None:
       return self.tryFallbackOrFail(requestParam, handler, "no entry %s in %s" % (entryName, zipname))
     handler.send_response(200)

--- a/server/handler/avndirectorybase.py
+++ b/server/handler/avndirectorybase.py
@@ -369,11 +369,11 @@ class AVNDirectoryHandlerBase(AVNWorker):
     zip = ZipFile(zipname)
     entry = None
     try:
-      if entryName.lower().endswith("doc.kml"):
-        # accept first .kml file found in root of archive, regardless of name
+      if (entryName.lower() == "doc.kml") and zipname.lower().endswith(".kmz"):
+        # when looking for *.kmz/doc.kml, accept first .kml file found in root, regardless of name
+        # just like it says in: https://developers.google.com/kml/documentation/kmzarchives#recommended-directory-structure
         for mbr in zip.infolist():
-          memname = mbr.filename.lower()
-          if ('/' not in memname) and memname.endswith('.kml'):
+          if ('/' not in mbr.filename) and mbr.filename.lower().endswith('.kml'):
             entry = mbr
             break
       else:

--- a/server/handler/avndirectorybase.py
+++ b/server/handler/avndirectorybase.py
@@ -369,7 +369,11 @@ class AVNDirectoryHandlerBase(AVNWorker):
     zip = ZipFile(zipname)
     entry = None
     try:
-      entry = zip.getinfo(entryName)
+      if entryName.lower().endswith("doc.kml"):
+        # get first entry, regardless of name
+        entry = zip.infolist()[0]
+      else:
+        entry = zip.getinfo(entryName)
     except KeyError as e:
       pass
     if entry is None:

--- a/server/handler/avndirectorybase.py
+++ b/server/handler/avndirectorybase.py
@@ -370,8 +370,12 @@ class AVNDirectoryHandlerBase(AVNWorker):
     entry = None
     try:
       if entryName.lower().endswith("doc.kml"):
-        # get first entry, regardless of name
-        entry = zip.infolist()[0]
+        # accept first .kml file found in root of archive, regardless of name
+        for mbr in zip.infolist():
+          memname = mbr.filename.lower()
+          if ('/' not in memname) and memname.endswith('.kml'):
+            entry = mbr
+            break
       else:
         entry = zip.getinfo(entryName)
     except KeyError as e:
@@ -379,7 +383,7 @@ class AVNDirectoryHandlerBase(AVNWorker):
     if entry is None:
       return self.tryFallbackOrFail(requestParam, handler, "no entry %s in %s" % (entryName, zipname))
     handler.send_response(200)
-    handler.send_header("Content-type", handler.getMimeType(entryName))
+    handler.send_header("Content-type", handler.getMimeType(entry.filename))
     handler.send_header("Content-Length", entry.file_size)
     fs = os.stat(zipname)
     handler.send_header("Last-Modified", handler.date_time_string(fs.st_mtime))

--- a/viewer/build.gradle
+++ b/viewer/build.gradle
@@ -23,6 +23,7 @@ node{
 */
 
 class MyNpm extends NpmTask{
+    @Internal
     def subDir
     @InputFiles
     def getInputFiles(){


### PR DESCRIPTION
Allows KMZ overlay to be attached to chart even if its first member is not named 'doc.kml'.  This works in the simple case that the KMZ archive contains exactly one KML file, but is arguably too simpleminded, it could break if KMZ file also had readme.txt or some other file in the root of the archive.  

Also including an unrelated fix to `viewer/build.gradle`, which failed for me using gradle 7.4.

