### PR TITLE
Fix permissions of avnav system user for serial/usb devices

### DIFF
--- a/linux/postinstall
+++ b/linux/postinstall
@@ -5,6 +5,12 @@ if [ "$x" = "" ] ; then
 else
     echo "user avnav already exists"
 fi
+
+if [ -z $(id avnav | grep dialout) ]
+then
+  usermod -aG dialout avnav
+fi
+
 BASE=/var/lib/avnav
 if [ ! -d $BASE ] ; then
     echo creating basedir $BASE


### PR DESCRIPTION
Hi @wellenvogel,

with the PR avnav is added to the group "dialout" to enable communication with usb/serial interfaces out-of-box in "default setup

greetings
free-x