### PR TITLE
revised VMC and HDG computation

### DIFF
--- a/server/handler/avnrouter.py
+++ b/server/handler/avnrouter.py
@@ -26,6 +26,7 @@
 #  so refer to this BSD licencse also (see ais.py) or omit ais.py 
 ###############################################################################
 import json
+import math
 import os
 import sys
 
@@ -168,13 +169,9 @@ class WpData:
     if v is None:
       return None
     return float(v)
-  def _calcVmg(self,targetCourse):
-    if self.course is None or self.speed is None or targetCourse is None:
-      return None
-    coursediff=min(abs(targetCourse-self.course),abs(targetCourse+360-self.course),abs(targetCourse-(self.course+360)))
-    if coursediff > 85:
-      return None
-    return self.speed * math.cos(math.pi/180*coursediff)
+  def _calcVmg(self, targetCourse):
+    if all(v is not None for v in [self.course, self.speed, targetCourse]):
+      return self.speed * math.cos(math.radians(targetCourse-self.course))
 
   def __init__(self,leg: AVNRoutingLeg = None,lat=None,lon=None,speed=None,course=None,useRhumLine=False):
     self.validData=False

--- a/viewer/nav/navcompute.js
+++ b/viewer/nav/navcompute.js
@@ -294,46 +294,33 @@ NavCompute.computeLegInfo=function(target,gps,opt_start){
         rt.markerCourseRhumbLine=pos.rhumbBearingTo(targetll);
         rt.markerDistanceGreatCircle=pos.distanceTo(targetll);
         rt.markerDistanceRhumbLine=pos.rhumbDistanceTo(targetll);
-        if (useRhumbLine){
+        if (useRhumbLine) {
             rt.markerCourse=rt.markerCourseRhumbLine;
             rt.markerDistance=rt.markerDistanceRhumbLine;
-        }
-        else{
+        } else {
             rt.markerCourse=rt.markerCourseGreatCircle;
             rt.markerDistance=rt.markerDistanceGreatCircle;
         }
-        let coursediff = Math.min(Math.abs(rt.markerCourse - gps.course), Math.abs(rt.markerCourse + 360 - gps.course),
-            Math.abs(rt.markerCourse - (gps.course + 360)));
-        if (gps.rtime && coursediff <= 85) {
-            //TODO: is this really correct for VMG?
-            let vmgapp = gps.speed * Math.cos(Math.PI / 180 * coursediff);
-            //vmgapp is in m/s
-            let targettime = gps.rtime.getTime();
-            rt.markerVmg = vmgapp;
-            if (vmgapp > 0) {
-                targettime += rt.markerDistance / vmgapp  * 1000; //time in ms
-                let targetDate = new Date(Math.round(targettime));
-                rt.markerEta = targetDate;
-            }
-            else {
-                rt.markerEta = null;
-            }
-        }
-        else {
+        // TODO: This is actually VMC not VMG
+        rt.markerVmg = gps.speed * Math.cos(Math.PI / 180 * (rt.markerCourse - gps.course));
+        if (gps.rtime && rt.markerVmg > 0) {
+            let targetTime = gps.rtime.getTime() + rt.markerDistance / rt.markerVmg * 1000;
+            let targetDate = new Date(Math.round(targetTime));
+            rt.markerEta = targetDate;
+        } else {
             rt.markerEta = null;
-            rt.markerVmg = 0;
         }
         if (opt_start) {
             rt.markerXte = useRhumbLine?
                 NavCompute.computeRhumbXte(opt_start,target,gps):
                 NavCompute.computeXte(opt_start,target, gps);
-        }
-        else{
+        } else {
             rt.markerXte=0;
         }
     }
     return rt;
 };
+
 NavCompute.NM=1852; //m per NM
 
 export default NavCompute;


### PR DESCRIPTION
Small changes you might want to add.

## allow VMC to be negative

- When moving away from the waypoint, the VMC is *negative* and not zero.
- It should be called [VMC not VMG ](https://www.navigation-mac.fr/vmg-vmc-pour-les-nuls/?lang=en)(this seems to be a common mistake).

Question: VMC(G) is computed twice
- in `avnrouter.py` and
- in `navcompute,js`

Why?

## scale heading vector with STW instead of SOG

- The dashed heading vector should be scaled with the STW (water speed) if available not SOG