### PR TITLE
Add route list name sorting

### DIFF
--- a/viewer/components/DownloadItemList.tsx
+++ b/viewer/components/DownloadItemList.tsx
@@ -123,11 +123,13 @@ export type DownloadItemListProps = {
     itemInfoFunction?:(item?:Item)=>ReactElement
     className?:string
     triggerCreateSequence?:number; //whenever set to != 0 or changed to !=0 a create dialog is triggered
+    sortFunction?:(a:Item,b:Item)=>number;
 }
 
 export const DownloadItemList = (
     {type, selectCallback, uploadFile,infoMode,noExtra,showCreate,itemActions,
-        autoreload,uploadDone,selectedName,scrollSelected,immediateSelect,itemInfoFunction,className,triggerCreateSequence}:DownloadItemListProps) => {
+        autoreload,uploadDone,selectedName,scrollSelected,immediateSelect,itemInfoFunction,className,triggerCreateSequence,
+        sortFunction}:DownloadItemListProps) => {
     const [items, setItems] = useState([]);
     const [vselectedName, setVselectedName,vSelectedNameRef] = useStateRef(selectedName);
     const lastSelectedName=useRef(undefined);
@@ -219,7 +221,7 @@ export const DownloadItemList = (
         displayList.push(DEFAULT_OVERLAY_CHARTENTRY)
     }
     if (type !== 'plugins') {
-        displayList.sort(itemSort);
+        displayList.sort(sortFunction || itemSort);
     }
     if (scrollSelected || vselectedName){
         lastSelectedName.current=vselectedName;

--- a/viewer/gui/EditRoutePage.tsx
+++ b/viewer/gui/EditRoutePage.tsx
@@ -269,6 +269,7 @@ const LoadRouteDialog=({blacklist,selectedRoute,resolveFunction,title,allowUploa
     const dialogContext=useDialogContext();
     const [,,connectedModeRef]=useStoreState(keys.gui.global.connectedMode);
     const [wrOnly,setWrOnly,wrOnlyRef]=useStateRef(true);
+    const [sortAscending,setSortAscending]=useState(true);
     const itemActions=createItemActions('route').copy({
         canModify:(item:RouteInfo)=>(!item.server || connectedModeRef.current),
         show:(item:RouteInfo)=>{
@@ -301,6 +302,14 @@ const LoadRouteDialog=({blacklist,selectedRoute,resolveFunction,title,allowUploa
             noExtra={true}
             infoMode={DownloadItemInfoMode.ICONS}
             itemActions={itemActions}
+            sortFunction={(a,b)=>{
+                const result=(a.name || '').localeCompare(
+                    b.name || '',
+                    undefined,
+                    {numeric:true,sensitivity:'base'}
+                );
+                return sortAscending ? result : -result;
+            }}
         />
         <UploadHandler
             local={true}
@@ -329,11 +338,17 @@ const LoadRouteDialog=({blacklist,selectedRoute,resolveFunction,title,allowUploa
         />
         <DialogButtons buttonList={[
             {
+                name:'RouteSort',
+                shortText:sortAscending ? 'Sort Z-A' : 'Sort A-Z',
+                close:false,
+                onClick:()=>setSortAscending((current)=>!current)
+            },
+            {
                 ...ButtonDefs.Upload,
-                onClick: ()=>uploadClick((ev)=>{
+                onClick:()=>uploadClick((ev)=>{
                     setUploadFile(ev.target.files[0]);
                 },".gpx"),
-                visible: allowUpload,
+                visible:allowUpload,
                 close:false
             },
             DBCancel()


### PR DESCRIPTION
Adds optional ascending/descending name sorting to the route load dialog.

Changes:
- adds an optional sortFunction to DownloadItemList
- keeps the existing default sorting for all other lists
- adds A-Z / Z-A sorting to Edit Route -> Load
- uses localeCompare with numeric sorting and case-insensitive comparison

Tested successfully on AVNav 20260712 in the route load dialog.